### PR TITLE
CI/CD: Use 4 digit versioning scheme when publishing from PR

### DIFF
--- a/.github/workflows/ext-publish-to-pypi.yml
+++ b/.github/workflows/ext-publish-to-pypi.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Use temp version if publishing to Test PyPI
         if: ${{ needs.determine-target.outputs.pypi-target == 'test' }}
         run: |
-          TMP_VERSION=9999.${{ github.run_id }}.${{ github.run_attempt }}
+          TMP_VERSION=9999.0.${{ github.run_id }}.${{ github.run_attempt }}
           echo "Setting temporary version to $TMP_VERSION for Test PyPI publishing"
           poetry version $TMP_VERSION
 


### PR DESCRIPTION
This will allow us to verify that the move to 4 digit versioning scheme for ChipScoPy will not impact user installs from PyPI