### PR TITLE
CI/CD: Use 1st party actions to deploy the GitHub Pages site

### DIFF
--- a/.github/workflows/ext-publish-to-gh-pages.yml
+++ b/.github/workflows/ext-publish-to-gh-pages.yml
@@ -23,6 +23,8 @@ on:
 
 permissions:
   contents: write
+  pages: write
+  id-token: write
 
 jobs:
   build-and-publish-docs:


### PR DESCRIPTION
# Pull Request Overview
This PR migrates the GitHub Pages deployment to use GitHub's official first-party actions (actions/configure-pages, actions/upload-pages-artifact, and actions/deploy-pages) instead of the previous custom approach that directly pushed to the gh-pages branch.

## Key Changes:

- Added a new deploy job that uses official GitHub Actions to deploy the gh-pages branch content
- Added documentation comments explaining the workflow structure and job relationships
- The deployment now uses a proper GitHub Pages environment with artifact-based deployment