### PR TITLE
CI: Use locked Poetry setup in release workflows

### DIFF
--- a/.github/workflows/ext-publish-to-gh-pages.yml
+++ b/.github/workflows/ext-publish-to-gh-pages.yml
@@ -57,6 +57,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Read Poetry version
+        id: poetry-version
+        run: echo "version=$(cat .poetry-version)" >> "$GITHUB_OUTPUT"
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -65,61 +69,10 @@ jobs:
       - name: Set up Poetry
         uses: abatilo/actions-poetry@v3
         with:
-          # TODO - Read this from .poetry-version file
-          poetry-version: 1.8.3
+          poetry-version: ${{ steps.poetry-version.outputs.version }}
 
-      # TODO - Once the poetry.lock file is available in the repo, we can simply run `poetry install`
       - name: Install documentation dependencies
-        run: |
-          cat > requirements.txt << 'EOF'
-          alabaster==0.7.13 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          antlr4-python3-runtime==4.13.1 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          babel==2.12.1 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          certifi==2023.7.22 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          charset-normalizer==3.2.0 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          click==8.1.7 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          colorama==0.4.6 ; python_full_version >= "3.8.3" and python_version < "4.0" and (sys_platform == "win32" or platform_system == "Windows")
-          commonmark==0.9.1 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          docutils==0.19 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          idna==3.4 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          imagesize==1.4.1 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          importlib-metadata==6.8.0 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          jinja2==3.1.2 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          loguru==0.7.1 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          markdown-it-py==3.0.0 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          markdown==3.4.4 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          markupsafe==2.1.3 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          mdurl==0.1.2 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          more-itertools==10.1.0 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          packaging==23.1 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          pillow==10.4.0 ; python_full_version >= "3.8.3" and python_version < "4"
-          pygments==2.16.1 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          pytz==2023.3.post1 ; python_full_version >= "3.8.3" and python_version < "3.9"
-          pyyaml==6.0.1 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          recommonmark==0.6.0 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          reportlab==4.0.4 ; python_full_version >= "3.8.3" and python_version < "4"
-          requests==2.29.0 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          rich==13.5.2 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          rst2pdf==0.99 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          smartypants==2.0.1 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          snowballstemmer==2.2.0 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          sphinx-autodoc-typehints==1.12.0 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          sphinx-markdown-tables==0.0.17 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          sphinx-rtd-theme==2.0.0 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          sphinx==6.2.1 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          sphinxcontrib-applehelp==1.0.4 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          sphinxcontrib-devhelp==1.0.2 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          sphinxcontrib-htmlhelp==2.0.1 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          sphinxcontrib-jquery==4.1 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          sphinxcontrib-jsmath==1.0.1 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          sphinxcontrib-qthelp==1.0.3 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          sphinxcontrib-serializinghtml==1.1.5 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          typing-extensions==4.7.1 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          urllib3==1.26.19 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          win32-setctime==1.1.0 ; python_full_version >= "3.8.3" and python_version < "4.0" and sys_platform == "win32"
-          zipp==3.16.2 ; python_full_version >= "3.8.3" and python_version < "4.0"
-          EOF
-          poetry run pip install -r requirements.txt
+        run: poetry install --with docs
 
       - name: Build documentation
         run: |

--- a/.github/workflows/ext-publish-to-pypi.yml
+++ b/.github/workflows/ext-publish-to-pypi.yml
@@ -60,6 +60,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Read Poetry version
+        id: poetry-version
+        run: echo "version=$(cat .poetry-version)" >> "$GITHUB_OUTPUT"
+
       - name: Remove examples from repo
         run: rm -rf chipscopy/examples
 
@@ -71,8 +75,7 @@ jobs:
       - name: Set up Poetry
         uses: abatilo/actions-poetry@v3
         with:
-          # TODO - Read this from .poetry-version file
-          poetry-version: 1.8.3
+          poetry-version: ${{ steps.poetry-version.outputs.version }}
 
       - name: Use temporary package version for PRs
         if: github.event_name == 'pull_request'

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,34 @@
+# Copyright (C) 2022-2024, Advanced Micro Devices, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,49 @@
+REM Copyright (C) 2023-2024, Advanced Micro Devices, Inc.
+REM
+REM Licensed under the Apache License, Version 2.0 (the "License");
+REM you may not use this file except in compliance with the License.
+REM You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/poetry.lock
+++ b/poetry.lock
@@ -3534,7 +3534,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,5 @@ target-version = ['py39']
 extend-exclude = '''chipscopy/tcf/.*$|docs/.*$|internal-examples/.*$|examples/.*$|tests/.*$'''
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "jupytext>=1.15"]
-build-backend = "build"
-backend-path = ["."]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- Read the Poetry version from `.poetry-version` in release workflows instead of hardcoding the old version.
- Replace the docs workflow's inline requirements list with `poetry install --with docs` so it uses `poetry.lock`.

## Test plan
- ReadLints for `.github/workflows/ext-publish-to-pypi.yml` and `.github/workflows/ext-publish-to-gh-pages.yml`
- `git diff --check -- .github/workflows/ext-publish-to-pypi.yml .github/workflows/ext-publish-to-gh-pages.yml`
- `rg` checks for the removed old Poetry pin and generated requirements install


Made with [Cursor](https://cursor.com)