### PR TITLE
CI: Add skip-publish validation mode + move to latest actions/*

### DIFF
--- a/.github/workflows/ext-publish-to-gh-pages.yml
+++ b/.github/workflows/ext-publish-to-gh-pages.yml
@@ -55,14 +55,14 @@ jobs:
           echo "::notice::Target path: $TARGET_PATH"
 
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7.0.0
 
       - name: Read Poetry version
         id: poetry-version
         run: echo "version=$(cat .poetry-version)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.10"
 
@@ -80,13 +80,13 @@ jobs:
           poetry run make html
 
       - name: Upload documentation artifacts
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: docs-build
           path: docs/_build/html/
 
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7.0.0
         with:
           ref: gh-pages
           path: gh-pages
@@ -106,7 +106,7 @@ jobs:
           echo "Created folder: ${{ steps.determine-release.outputs.target-path }}"
 
       - name: Download and copy built documentation
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8.0.1
         with:
           name: docs-build
           path: docs-build-temp
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7.0.0
         with:
           ref: gh-pages
 
@@ -183,18 +183,18 @@ jobs:
 
     steps:
       - name: Checkout the gh-pages branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7.0.0
         with:
           ref: gh-pages
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: "."
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/ext-publish-to-pypi.yml
+++ b/.github/workflows/ext-publish-to-pypi.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7.0.0
 
       - name: Read Poetry version
         id: poetry-version
@@ -73,7 +73,7 @@ jobs:
         run: rm -rf chipscopy/examples
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.10"
 
@@ -100,7 +100,7 @@ jobs:
           echo "::notice::Package version: $VERSION"
 
       - name: Upload distributions as job artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: release-dists
           path: dist/
@@ -127,7 +127,7 @@ jobs:
 
     steps:
       - name: Download release distributions from job artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8.0.1
         with:
           name: release-dists
           path: dist/
@@ -160,13 +160,13 @@ jobs:
     
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.10"
 
       - name: Download release distributions from job artifact
         if: ${{ inputs.skip-publish == true }}
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8.0.1
         with:
           name: release-dists
           path: dist/

--- a/.github/workflows/ext-publish-to-pypi.yml
+++ b/.github/workflows/ext-publish-to-pypi.yml
@@ -19,6 +19,11 @@ on:
         options:
           - 'test'
           - 'prod'
+      skip-publish:
+        description: 'Build and validate distributions without uploading to PyPI'
+        required: false
+        default: false
+        type: boolean
 
   pull_request:
     branches:
@@ -102,7 +107,7 @@ jobs:
 
   pypi-publish:
     name: Publish to PyPI (${{ needs.determine-target.outputs.pypi-target }} instance)
-    if: github.event_name == 'workflow_dispatch' 
+    if: github.event_name == 'workflow_dispatch' && inputs.skip-publish != true
     runs-on: ubuntu-latest
     
     needs:
@@ -142,6 +147,7 @@ jobs:
 
   verify-install:
     name: Verify Installation (${{ matrix.os }})
+    if: ${{ always() && github.event_name == 'workflow_dispatch' && needs.release-build.result == 'success' && (inputs.skip-publish == true || needs.pypi-publish.result == 'success') }}
     runs-on: ${{ matrix.os }}
     needs:
       - determine-target
@@ -157,21 +163,34 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+
+      - name: Download release distributions from job artifact
+        if: ${{ inputs.skip-publish == true }}
+        uses: actions/download-artifact@v5
+        with:
+          name: release-dists
+          path: dist/
+
+      - name: Install from local distributions
+        if: ${{ inputs.skip-publish == true }}
+        run: python -m pip install dist/*.whl
+        shell: bash
       
       - name: Wait for package to be available
+        if: ${{ inputs.skip-publish != true }}
         run: |
           echo "Waiting 120 seconds for package to propagate..."
           sleep 120
         shell: bash
       
       - name: Install from Test PyPI
-        if: ${{ needs.determine-target.outputs.pypi-target == 'test' }}
+        if: ${{ inputs.skip-publish != true && needs.determine-target.outputs.pypi-target == 'test' }}
         run: |
           pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ chipscopy==${{ needs.release-build.outputs.package-version }}
         shell: bash
       
       - name: Install from Prod PyPI
-        if: ${{ needs.determine-target.outputs.pypi-target == 'prod' }}
+        if: ${{ inputs.skip-publish != true && needs.determine-target.outputs.pypi-target == 'prod' }}
         run: |
           pip install chipscopy==${{ needs.release-build.outputs.package-version }}
         shell: bash


### PR DESCRIPTION
## Summary
- Add a `skip-publish` workflow_dispatch input for release validation runs that build distributions without uploading to PyPI.
- Skip the PyPI publish job when requested, then verify installation from the release artifact.
- Update first-party GitHub Actions to latest release tags checked from GitHub releases/web search: checkout v7.0.0, setup-python v6.3.0, upload-artifact v7.0.1, download-artifact v8.0.1, configure-pages v6.0.0, upload-pages-artifact v5.0.0, deploy-pages v5.0.0.

## Test plan
- [x] `git diff --check origin/master...HEAD`
- [x] Cursor lints for edited workflow files
- [ ] `poetry run pytest chipscopy/tcf/tests` (not run locally: `poetry` is not installed)
- [ ] `python -m pytest chipscopy/tcf/tests` (not run locally: `pytest` is not installed)